### PR TITLE
types - add missing property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 declare class Item {
     constructor(type: number, count: number, metadata?: number, nbt?: object);
     type: number;
+    slot: number;
     count: number;
     metadata: number;
     nbt: Buffer | null;


### PR DESCRIPTION
add missing property.

Currently `Item` class does not have the `slot` property.