### PR TITLE
Fix typo in index.d.ts imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { Tag, TagType } from 'prismarine-nbt'
+import { Tags, TagType } from 'prismarine-nbt'
 
 declare class Item {
     constructor(type: number, count: number, metadata?: number, nbt?: object);


### PR DESCRIPTION
https://github.com/PrismarineJS/prismarine-item/commit/9c24209491046e9e9c0a8645f4d90ee85ec6e06b seems to import `Tag` instead of `Tags`. This causes errors when compiling Typescript.

For reference, here is where `prismarine-nbt` exports `Tags`.
https://github.com/PrismarineJS/prismarine-nbt/blob/2e9cb0e1549fb6403d64cefc52af52bd904efd83/typings/index.d.ts#L22-L35