### PR TITLE
Handling of unexpected enchantment IDs causing various type errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function loader (version) {
         } else {
           itemEnch = []
         }
-        return itemEnch.map(ench => ({ lvl: ench.lvl, name: mcData.enchantments[ench.id].name }))
+        return itemEnch.map(ench => ({ lvl: ench.lvl, name: mcData.enchantments[ench.id]?.name || ench.id }))
       } else {
         let itemEnch = []
         if (this?.nbt?.value?.Enchantments) {


### PR DESCRIPTION
```
return ({ lvl: ench.lvl, name: mcData.enchantments[ench.id].name })
                                                                                               ^
TypeError: Cannot read properties of undefined (reading 'name')
    at /home/user/Developer/node/node_modules/prismarine-item/index.js:131:71
    at Array.map (<anonymous>)
```

This occurs when attempting to read enchantments from items with abnormal enchantments (ie. glowing enchantment effect, no enchantment description). If the enchantment name isn't present, it will now default to returning its identifier