### PR TITLE
feat(): Begin bedrock support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 import { Tags, TagType } from 'prismarine-nbt'
 
-type ItemLike = Item | null
+type ItemLike = Item | BedrockItem | null
 
 declare class Item {
     constructor(type: number, count: number, metadata?: number, nbt?: object);
@@ -26,6 +26,10 @@ declare class Item {
     static anvil (itemOne: ItemLike, itemTwo: ItemLike, creative: boolean, rename: string | undefined): { xpCost: number, item: ItemLike }
 }
 
+declare class BedrockItem extends Item {
+    constructor(type: number, count: number, metadata?: number, nbt?: object, itemStates?: ItemState[]);
+}
+
 declare interface NotchItem {
     // 1.8 - 1.12
     blockId?: number;
@@ -43,4 +47,11 @@ declare interface NormalizedEnchant {
     lvl: number
 }
 
-export default function loader(mcVersion: string): typeof Item;
+// For bedrock edition
+type ItemState = {
+    name: string
+    runtime_id: number
+    component_based: boolean
+}
+
+export default function loader(mcVersion: string): typeof Item | BedrockItem;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,8 @@ declare class Item {
 }
 
 declare class BedrockItem extends Item {
-    constructor(type: number, count: number, metadata?: number, nbt?: object, itemStates?: ItemState[]);
+    static loadItemStates(itemStates: ItemState[]): void;
+    constructor(type: number, count: number, metadata?: number, nbt?: object);
 }
 
 declare interface NotchItem {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,24 @@ function loader (registryOrVersion) {
         }
         if (item.nbt && item.nbt.length !== 0) { notchItem.nbtData = item.nbt }
         return notchItem
+      } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
+        if (item == null) return { network_id: -1 }
+        const notchItem = {
+          network_id: item.type,
+          count: item.count,
+          metadata: item.metadata,
+          has_stack_id: 0,
+          block_runtime_id: 0,
+          extra: {
+            has_nbt: 0,
+            can_place_on : [],
+            can_destroy: []
+          }
+        }
+        if (item.nbt && item.nbt.length !== 0) { 
+          notchItem.extra.nbt = item.nbt
+        }
+        return notchItem
       }
       throw new Error("Don't know how to serialize for this mc version ")
     }
@@ -80,6 +98,9 @@ function loader (registryOrVersion) {
       } else if (registry.supportFeature('itemSerializationUsesBlockId')) {
         if (item.blockId === -1) return null
         return new Item(item.blockId, item.itemCount, item.itemDamage, item.nbtData)
+      } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
+        if (!item.metadata && !item.metadata !== 0) return null
+        return new Item(item.networkId, item.count || 0, item.metadata, item.nbtData)
       }
       throw new Error("Don't know how to deserialize for this mc version ")
     }

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function loader (registryOrVersion) {
         return new Item(item.blockId, item.itemCount, item.itemDamage, item.nbtData)
       } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
         if (!item.metadata && item.metadata !== 0) return null
-        return new Item(item.network_id, item.count || 0, item.metadata, item.nbtData)
+        return new Item(item.network_id, item.count || 0, item.metadata, item.extra?.nbt)
       }
       throw new Error("Don't know how to deserialize for this mc version ")
     }

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function loader (registryOrVersion) {
         return new Item(item.blockId, item.itemCount, item.itemDamage, item.nbtData)
       } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
         if (!item.metadata && item.metadata !== 0) return null
-        return new Item(item.network_id, item.count || 0, item.metadata, item.extra?.nbt)
+        return new Item(item.network_id, item.count || 0, item.metadata, item.extra?.nbt.nbt)
       }
       throw new Error("Don't know how to deserialize for this mc version ")
     }

--- a/index.js
+++ b/index.js
@@ -76,11 +76,11 @@ function loader (registryOrVersion) {
           block_runtime_id: 0,
           extra: {
             has_nbt: 0,
-            can_place_on : [],
+            can_place_on: [],
             can_destroy: []
           }
         }
-        if (item.nbt && item.nbt.length !== 0) { 
+        if (item.nbt && item.nbt.length !== 0) {
           notchItem.extra.nbt = item.nbt
         }
         return notchItem
@@ -99,8 +99,8 @@ function loader (registryOrVersion) {
         if (item.blockId === -1) return null
         return new Item(item.blockId, item.itemCount, item.itemDamage, item.nbtData)
       } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
-        if (!item.metadata && !item.metadata !== 0) return null
-        return new Item(item.networkId, item.count || 0, item.metadata, item.nbtData)
+        if (!item.metadata && item.metadata !== 0) return null
+        return new Item(item.network_id, item.count || 0, item.metadata, item.nbtData)
       }
       throw new Error("Don't know how to deserialize for this mc version ")
     }

--- a/index.js
+++ b/index.js
@@ -227,8 +227,18 @@ function loader (registryOrVersion) {
     }
   }
 
+  class BedrockItem extends Item {
+    constructor (type, count, metadata, nbt, itemStates) {
+      super(type, count, metadata, nbt)
+      if (itemStates && !registry.loadedItemStates) {
+        registry.loadItemStates(itemStates)
+      }
+    }
+  }
+
   Item.anvil = require('./lib/anvil.js')(registry, Item)
-  return Item
+  BedrockItem.anvil = require('./lib/anvil.js')(registry, BedrockItem)
+  return registry.version.type === 'bedrock' ? BedrockItem : Item
 }
 
 module.exports = loader

--- a/index.js
+++ b/index.js
@@ -228,11 +228,8 @@ function loader (registryOrVersion) {
   }
 
   class BedrockItem extends Item {
-    constructor (type, count, metadata, nbt, itemStates) {
-      super(type, count, metadata, nbt)
-      if (itemStates && !registry.loadedItemStates) {
-        registry.loadItemStates(itemStates)
-      }
+    static loadItemStates (itemStates) {
+      registry.loadItemStates(itemStates)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function loader (registryOrVersion) {
         return new Item(item.blockId, item.itemCount, item.itemDamage, item.nbtData)
       } else if (registry.supportFeature('itemSerializationUsesNetworkId')) {
         if (!item.metadata && item.metadata !== 0) return null
-        return new Item(item.network_id, item.count || 0, item.metadata, item.extra?.nbt.nbt)
+        return new Item(item.network_id, item.count || 0, item.metadata, item.extra?.nbt?.nbt)
       }
       throw new Error("Don't know how to deserialize for this mc version ")
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "homepage": "https://github.com/PrismarineJS/prismarine-item#readme",
   "dependencies": {
     "prismarine-nbt": "^2.0.0",
-    "prismarine-registry": "github:ATXLtheAxolotl/prismarine-registry"
+    "prismarine-registry": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "homepage": "https://github.com/PrismarineJS/prismarine-item#readme",
   "dependencies": {
     "prismarine-nbt": "^2.0.0",
-    "prismarine-registry": "^1.4.0"
+    "prismarine-registry": "github:ATXLtheAxolotl/prismarine-registry"
   }
 }


### PR DESCRIPTION
There are three issues with this PR that I know of atm:

- The information about items in minecraft-data is outdated/incorrect, for example glass being identified as crimson_nylium.
- The `spawnEggMobName` getter will not work correctly because the spawn egg display name isn't stored in the nbt and we can't rely on the inaccurate data for the spawn egg name.
- This PR relies on PrismarineJS/minecraft-data#667

Hopefully this PR can help knock off another thing in this [list](https://github.com/PrismarineJS/bedrock-protocol/issues/116#issuecomment-1172949647).