### PR TITLE
Exporting types, making JSDoc more specific and some minor stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,9 @@
 
 import { Tags, TagType } from 'prismarine-nbt'
 
-type ItemLike = Item | null
+export type ItemLike = Item | null
 
-declare class Item {
+export declare class Item {
     constructor(type: number, count: number, metadata?: number, nbt?: object);
     type: number;
     slot: number;
@@ -26,7 +26,7 @@ declare class Item {
     static anvil (itemOne: ItemLike, itemTwo: ItemLike, creative: boolean, rename: string | undefined): { xpCost: number, item: ItemLike }
 }
 
-declare interface NotchItem {
+export declare interface NotchItem {
     // 1.8 - 1.12
     blockId?: number;
     itemDamage?: number;
@@ -38,7 +38,7 @@ declare interface NotchItem {
     nbtData?: Buffer;
 }
 
-declare interface NormalizedEnchant {
+export declare interface NormalizedEnchant {
     name: string;
     lvl: number
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function loader (registryOrVersion) {
     constructor (type, count, metadata, nbt) {
       if (type == null) return
 
-      if (metadata instanceof Object && metadata !== null) {
+      if (metadata instanceof Object) {
         nbt = metadata
         metadata = 0
       }

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -50,7 +50,8 @@ function loader (registry, Item) {
    *
    * @param {Item} itemOne left hand item
    * @param {Item} itemTwo right hand item
-   * @returns {xpLevelCost, finalEnchs}
+   * @param {boolean} creative whether the bot is in creative mode
+   * @returns {{finalEnchs: (*|[]|{lvl: *, name: *|null}[]|NormalizedEnchant[]), xpLevelCost: number}}
    * xpLevelCost is enchant data that is strictly from combining enchants
    * finalEnchs is the array of enchants on the final object
    */
@@ -108,7 +109,7 @@ function loader (registry, Item) {
    *
    * @param {Item} itemOne left hand item
    * @param {Item} itemTwo right hand item
-   * @returns {xpLevelCost, fixedDurability, usedMats}
+   * @returns {{usedMats: number, fixedDurability: number, xpLevelCost: number}|number}
    * xpLevelCost is the number of xp levels used for repair (if any)
    * fixedDurability is duribility after using the anvil
    * usedMats is the number of materials used to fix the broken item (if many mats is used)

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -5,7 +5,7 @@ function loader (registry, Item) {
       finalEnchs: [],
       fixedDurability: 0
     }
-    let onlyRename = false // to tell if its just a rename
+    let onlyRename = false // to tell if it's just a rename
     if (!combinePossible(itemOne, itemTwo) && itemTwo !== null) return { xpCost: 0, item: null }
     let cost = 0
     if (rename) {


### PR DESCRIPTION
The commits basically say everything, but here's a list:

- Made JSDoc more specific
  - Added creative property to combineEnchants function
  - Made return more specific in the combineEnchants and getRepairCost functions
- Simplified metadata check in the Item constructor, detailed explanation is in the commit
- Exporting all Typescript Types, so people can actually make use of them
- Fixing a typo, its --> it's
- Ignoring config directory of JetBrains IDEs in .gitignore because, well, it's kinda pointless to push it 