### PR TITLE
Don't add NBT data for full durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ console.log(Item.fromNotch(notchItem))
 
 ## API
 
-### Item(type, count[, metadata, nbt, stackId])
+### Item(type, count[[, metadata], nbt, stackId, fromServer = false])
 
 #### Item.toNotch(item[, serverAuthoritative])
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,13 +5,14 @@ import { Tags, TagType } from 'prismarine-nbt'
 export type ItemLike = Item | null
 
 export class Item {
-  constructor(type: number, count: number, metadata?: number, nbt?: object, stackId?: number);
+  constructor(type: number, count: number, metadata?: number, nbt?: object, stackId?: number, fromServer = false);
   type: number;
   slot: number;
   count: number;
   metadata: number;
   nbt: Tags[TagType] | null;
   stackId: number | null;
+  fromServer: boolean;
   name: string;
   displayName: string;
   stackSize: number;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function loader (registryOrVersion) {
         }
 
         // The 'itemEnum.maxDurability' checks to see if this item can lose durability
-        if (itemEnum.maxDurability && !this.durabilityUsed) this.durabilityUsed = 0
+        if (registry.supportFeature('explicitMaxDurability') && itemEnum.maxDurability && !this.durabilityUsed) this.durabilityUsed = 0
       } else {
         this.name = 'unknown'
         this.displayName = 'unknown'
@@ -310,7 +310,6 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!value) return
         if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {

--- a/index.js
+++ b/index.js
@@ -307,7 +307,10 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt?.value?.Damage) return
+        if (!this?.nbt) {
+          if (!value) return
+          this.nbt = nbt.comp({})
+        }
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt) this.nbt = nbt.comp({})
+        if (!this?.nbt) return
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/index.js
+++ b/index.js
@@ -311,7 +311,10 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt) this.nbt = nbt.comp({})
+        if (!this?.nbt) {
+          if(!value) return
+          this.nbt = nbt.comp({})
+        }
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/index.js
+++ b/index.js
@@ -68,8 +68,7 @@ function loader (registryOrVersion) {
     }
 
     static toNotch (item, serverAuthoritative = true) {
-      const hasNBT = item && item.nbt && Object.keys(item.nbt.value).length > 0
-
+      const hasNBT = !!(item && item.nbt && Object.keys(item.nbt.value).length > 0)
       if (registry.type === 'pc') {
         if (registry.supportFeature('itemSerializationAllowsPresent')) {
           if (item == null) return { present: false }
@@ -311,10 +310,8 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt) {
-          if (!value) return
-          this.nbt = nbt.comp({})
-        }
+        if (!value || value === 0) return
+        if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ function loader (registryOrVersion) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
         if (!this?.nbt) {
-          if(!value) return
+          if (!value) return
           this.nbt = nbt.comp({})
         }
         this.nbt.value.Damage = nbt.int(value)

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function loader (registryOrVersion) {
           const variation = itemEnum.variations.find((item) => item.metadata === metadata)
           if (variation) this.displayName = variation.displayName
         }
+
+        if (itemEnum.maxDurability && !this.durabilityUsed) this.durabilityUsed = 0
       } else {
         this.name = 'unknown'
         this.displayName = 'unknown'
@@ -307,6 +309,7 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
+        if (!this?.nbt?.value?.Damage && value === 0 && !registry.supportFeature('explicitMaxDurability')) return
         if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {

--- a/index.js
+++ b/index.js
@@ -34,9 +34,6 @@ function loader (registryOrVersion) {
           const variation = itemEnum.variations.find((item) => item.metadata === metadata)
           if (variation) this.displayName = variation.displayName
         }
-
-        // The 'itemEnum.maxDurability' checks to see if this item can lose durability
-        if (registry.supportFeature('explicitMaxDurability') && itemEnum.maxDurability && !this.durabilityUsed) this.durabilityUsed = 0
       } else {
         this.name = 'unknown'
         this.displayName = 'unknown'

--- a/index.js
+++ b/index.js
@@ -307,7 +307,6 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt?.value?.Damage && !value) return
         if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!value || value === 0) return
+        if (!value) return
         if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {

--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt) return
+        if (!this?.nbt?.value?.Damage) return
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/index.js
+++ b/index.js
@@ -307,10 +307,8 @@ function loader (registryOrVersion) {
     set durabilityUsed (value) {
       const where = registry.supportFeature('whereDurabilityIsSerialized')
       if (where === 'Damage') {
-        if (!this?.nbt) {
-          if (!value) return
-          this.nbt = nbt.comp({})
-        }
+        if (!this?.nbt?.value?.Damage && !value) return
+        if (!this?.nbt) this.nbt = nbt.comp({})
         this.nbt.value.Damage = nbt.int(value)
       } else if (where === 'metadata') {
         this.metadata = value

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -44,8 +44,8 @@ function loader (registry, Item) {
       if (data?.finalEnchs.length > 0) finalItem.enchants = data.finalEnchs
       if (rename) finalItem.customName = renamedName
       finalItem.repairCost = repairCost
-
-      if (itemOne.name !== 'enchanted_book') finalItem.durabilityUsed = itemOne.durabilityUsed - data.fixedDurability
+      const newDurability = itemOne.durabilityUsed - data.fixedDurability
+      if (itemOne.name !== 'enchanted_book' && newDurability > 0) finalItem.durabilityUsed = newDurability
     }
     return { xpCost: cost, item: finalItem, usedMats: data.usedMats }
   }

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -44,8 +44,7 @@ function loader (registry, Item) {
       if (data?.finalEnchs.length > 0) finalItem.enchants = data.finalEnchs
       if (rename) finalItem.customName = renamedName
       finalItem.repairCost = repairCost
-      const newDurability = itemOne.durabilityUsed - data.fixedDurability
-      if (itemOne.name !== 'enchanted_book' && newDurability > 0) finalItem.durabilityUsed = newDurability
+      if (itemOne.name !== 'enchanted_book') finalItem.durabilityUsed = itemOne.durabilityUsed - data.fixedDurability
     }
     return { xpCost: cost, item: finalItem, usedMats: data.usedMats }
   }

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -44,6 +44,7 @@ function loader (registry, Item) {
       if (data?.finalEnchs.length > 0) finalItem.enchants = data.finalEnchs
       if (rename) finalItem.customName = renamedName
       finalItem.repairCost = repairCost
+
       if (itemOne.name !== 'enchanted_book') finalItem.durabilityUsed = itemOne.durabilityUsed - data.fixedDurability
     }
     return { xpCost: cost, item: finalItem, usedMats: data.usedMats }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -28,19 +28,19 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(472, 1)
 
     it('constructor makes item correctly', () => {
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, stackSize: 1, type: 472, stackId: null }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(expectedObj)
     })
 
     it('use .toNotch', () => {
-      const expectedObj = { itemCount: 1, itemId: 472, present: true, nbtData: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } } }
+      const expectedObj = { itemCount: 1, itemId: 472, present: true, nbtData: undefined }
       expect(Item.toNotch(ironShovelItem)).toStrictEqual(expectedObj)
     })
 
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, stackSize: 1, type: 472, stackId: null }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })
@@ -50,18 +50,18 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(registry.itemsByName.iron_shovel.id, 1)
 
     it('constructor makes item correctly', () => {
-      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0 }
+      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: null, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0 }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(val)
     })
 
     it('use .toNotch', () => {
-      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: true, nbt: { version: 1, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } } }, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
+      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: false, nbt: undefined, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
     })
 
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0 }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0 }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })
@@ -137,12 +137,12 @@ describe('get Item.enchants', () => {
     const Item = require('prismarine-item')('1.16.5')
 
     it('diamond sword (unenchanted)', () => {
-      const item = Item.fromNotch({ present: true, itemId: 603, itemCount: 1, nbtData: { type: 'compound', name: '', value: { Damage: { type: 'int', value: 0 } } } })
+      const item = Item.fromNotch({ present: true, itemId: 603, itemCount: 1 })
       const enchs = item.enchants
       expect(enchs).toStrictEqual([])
     })
     it('iron shovel w/ eff2 for2 ub2', () => {
-      const item = Item.fromNotch({ present: true, itemId: 600, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 3 }, Damage: { type: 'int', value: 0 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:efficiency' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:fortune' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:unbreaking' } }] } } } } })
+      const item = Item.fromNotch({ present: true, itemId: 600, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 3 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:efficiency' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:fortune' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:unbreaking' } }] } } } } })
       const enchs = item.enchants
       expect(enchs).toStrictEqual([{ lvl: 2, name: 'efficiency' }, { lvl: 2, name: 'fortune' }, { lvl: 2, name: 'unbreaking' }])
     })
@@ -157,7 +157,7 @@ describe('get Item.enchants', () => {
       expect(enchs).toStrictEqual([])
     })
     it('fishing rod w/ mending', () => {
-      const item = Item.fromNotch({ present: true, itemId: 684, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 1 }, Damage: { type: 'int', value: 0 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 1 }, id: { type: 'string', value: 'minecraft:mending' } }] } } } } })
+      const item = Item.fromNotch({ present: true, itemId: 684, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 1 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 1 }, id: { type: 'string', value: 'minecraft:mending' } }] } } } } })
       const enchs = item.enchants
       expect(enchs).toStrictEqual([{ lvl: 1, name: 'mending' }])
     })
@@ -315,14 +315,14 @@ describe('set item.enchants', () => {
     const Item = require('prismarine-item')('1.16.5')
     it('diamond sword (unenchanted)', () => {
       const newItem = new Item(603, 1)
-      const item = Item.fromNotch({ present: true, itemId: 603, itemCount: 1, nbtData: { type: 'compound', name: '', value: { Damage: { type: 'int', value: 0 } } } })
+      const item = Item.fromNotch({ present: true, itemId: 603, itemCount: 1 })
       const enchs = item.enchants
       newItem.enchants = enchs
       expect(newItem).toStrictEqual(item)
     })
     it('iron shovel w/ eff2 for2 ub2', () => {
       const newItem = new Item(600, 1)
-      const item = Item.fromNotch({ present: true, itemId: 600, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 3 }, Damage: { type: 'int', value: 0 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:efficiency' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:fortune' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:unbreaking' } }] } } } } })
+      const item = Item.fromNotch({ present: true, itemId: 600, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 3 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:efficiency' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:fortune' } }, { lvl: { type: 'short', value: 2 }, id: { type: 'string', value: 'minecraft:unbreaking' } }] } } } } })
       const enchs = item.enchants
       newItem.enchants = enchs
       newItem.repairCost = 3
@@ -338,7 +338,7 @@ describe('set item.enchants', () => {
     })
     it('fishing rod w/ mending', () => {
       const newItem = new Item(684, 1)
-      const item = Item.fromNotch({ present: true, itemId: 684, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 1 }, Damage: { type: 'int', value: 0 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 1 }, id: { type: 'string', value: 'minecraft:mending' } }] } } } } })
+      const item = Item.fromNotch({ present: true, itemId: 684, itemCount: 1, nbtData: { type: 'compound', name: '', value: { RepairCost: { type: 'int', value: 1 }, Enchantments: { type: 'list', value: { type: 'compound', value: [{ lvl: { type: 'short', value: 1 }, id: { type: 'string', value: 'minecraft:mending' } }] } } } } })
       const enchs = item.enchants
       newItem.enchants = enchs
       newItem.repairCost = 1

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -8,7 +8,7 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(256, 1)
 
     it('constructor makes item correctly', () => {
-      const val = { type: 256, count: 1, metadata: 0, nbt: null, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: null }
+      const val = { type: 256, count: 1, metadata: 0, nbt: null, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: null, fromServer: false }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(val)
     })
 
@@ -19,7 +19,7 @@ describe('test based on examples', () => {
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 256, stackId: null }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 256, stackId: null, fromServer: false }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })
@@ -28,7 +28,7 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(472, 1)
 
     it('constructor makes item correctly', () => {
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null, fromServer: false }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(expectedObj)
     })
 
@@ -40,7 +40,7 @@ describe('test based on examples', () => {
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: 472, stackId: null, fromServer: false }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })
@@ -50,18 +50,18 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(registry.itemsByName.iron_shovel.id, 1)
 
     it('constructor makes item correctly', () => {
-      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0 }
+      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: null, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0, fromServer: false }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(val)
     })
 
     it('use .toNotch', () => {
-      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: true, nbt: { version: 1, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } } }, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
+      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: false, nbt: null, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
     })
 
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0 }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0, fromServer: false }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -50,18 +50,18 @@ describe('test based on examples', () => {
     const ironShovelItem = new Item(registry.itemsByName.iron_shovel.id, 1)
 
     it('constructor makes item correctly', () => {
-      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: null, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0 }
+      const val = { type: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, name: 'iron_shovel', displayName: 'Iron Shovel', stackSize: 1, stackId: 0 }
       expect(JSON.parse(JSON.stringify(ironShovelItem))).toStrictEqual(val)
     })
 
     it('use .toNotch', () => {
-      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: false, nbt: undefined, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
+      expect(Item.toNotch(ironShovelItem)).toStrictEqual({ network_id: registry.itemsByName.iron_shovel.id, count: 1, metadata: 0, has_stack_id: true, stack_id: 0, block_runtime_id: 0, extra: { has_nbt: true, nbt: { version: 1, nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } } }, can_place_on: [], can_destroy: [], blocking_tick: 0 } })
     })
 
     it('use .fromNotch', () => {
       const toNotch = Item.toNotch(ironShovelItem)
       const fromNotch = Item.fromNotch(toNotch)
-      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: null, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0 }
+      const expectedObj = { count: 1, displayName: 'Iron Shovel', metadata: 0, name: 'iron_shovel', nbt: { name: '', type: 'compound', value: { Damage: { type: 'int', value: 0 } } }, stackSize: 1, type: registry.itemsByName.iron_shovel.id, stackId: 0 }
       expect(JSON.parse(JSON.stringify(fromNotch))).toStrictEqual(expectedObj)
     })
   })


### PR DESCRIPTION
Creating NBT data for full durability causes mismatch with the server leading to it rejecting transactions involving the item.

Closes [#3129](https://github.com/PrismarineJS/mineflayer/issues/3129)

I believe it might be problematic to add NBT data manually (as opposed to retrieving the updated item from the server) in general, but that isn't immediately relevant as it will not typically cause a mismatch