### PR TITLE
fix displayName for items that are also blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ function loader (registryOrVersion) {
         this.stackSize = itemEnum.stackSize
         this.maxDurability = itemEnum.maxDurability
 
-        const blockEnum = registry.blocks[type]
-        if ('variations' in itemEnum || 'variations' in blockEnum) {
-          const variation = (itemEnum.variations ?? blockEnum.variations).find(variation => variation.metadata === metadata)
+        const variations = itemEnum.variations ?? blockEnum.variations
+        if (variations) {
+          const variation = variations.find(variation => variation.metadata === metadata)
           if (variation) this.displayName = variation.displayName
         }
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function loader (registryOrVersion) {
         this.stackSize = itemEnum.stackSize
         this.maxDurability = itemEnum.maxDurability
 
+        const blockEnum = registry.blocks[type]
         const variations = itemEnum.variations ?? blockEnum.variations
         if (variations) {
           const variation = variations.find(variation => variation.metadata === metadata)

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function loader (registryOrVersion) {
         this.maxDurability = itemEnum.maxDurability
 
         const blockEnum = registry.blocks[type]
-        const variations = itemEnum.variations ?? blockEnum.variations
+        const variations = itemEnum.variations ?? blockEnum?.variations
         if (variations) {
           const variation = variations.find(variation => variation.metadata === metadata)
           if (variation) this.displayName = variation.displayName

--- a/index.js
+++ b/index.js
@@ -33,8 +33,9 @@ function loader (registryOrVersion) {
         this.stackSize = itemEnum.stackSize
         this.maxDurability = itemEnum.maxDurability
 
-        if ('variations' in itemEnum) {
-          const variation = itemEnum.variations.find((item) => item.metadata === metadata)
+        const blockEnum = registry.blocks[type]
+        if ('variations' in itemEnum || 'variations' in blockEnum) {
+          const variation = (itemEnum.variations ?? blockEnum.variations).find(variation => variation.metadata === metadata)
           if (variation) this.displayName = variation.displayName
         }
 


### PR DESCRIPTION
items which are also blocks lack variations in their spec, leading to wrong displayNames

i assume the correct path to fixing this is to check if the item is also a block and use the displayName from the block variation if applicable