### PR TITLE
Fix typing error in loader function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,4 +40,4 @@ export class Item {
   static nextStackId(): number;
 }
 
-export default function loader(mcVersion: string): typeof Item;
+export default function loader(mcVersion: string | object): typeof Item;


### PR DESCRIPTION
Fixes #111

Update the `loader` function in `index.d.ts` to accept either a string `mcVersion` or a `bot.registry` object.

* Modify the TypeScript definition to reflect the possible `bot.registry` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PrismarineJS/prismarine-item/pull/122?shareId=4bbb2ec7-e848-417f-974c-18226974e117).