### PR TITLE
fix: Item.equal now compares components on 1.20.5+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,22 @@
 const nbt = require('prismarine-nbt')
 
+// pc 1.20.5+: item data lives in components instead of nbt, so equality must compare them too
+function componentsEqual (item1, item2) {
+  const map1 = item1.componentMap
+  const map2 = item2.componentMap
+  if (map1 === undefined && map2 === undefined) return true
+  if (map1 === undefined || map2 === undefined) return false
+  if (map1.size !== map2.size) return false
+  for (const [type, component1] of map1) {
+    const component2 = map2.get(type)
+    if (component2 === undefined || JSON.stringify(component1) !== JSON.stringify(component2)) return false
+  }
+  const removed1 = item1.removedComponents ?? []
+  const removed2 = item2.removedComponents ?? []
+  if (removed1.length !== removed2.length) return false
+  return JSON.stringify([...removed1].sort()) === JSON.stringify([...removed2].sort())
+}
+
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
   class Item {
@@ -69,7 +86,8 @@ function loader (registryOrVersion) {
           item1.type === item2.type &&
           item1.metadata === item2.metadata &&
           (matchStackSize ? item1.count === item2.count : true) &&
-          (matchNbt ? JSON.stringify(item1.nbt) === JSON.stringify(item2.nbt) : true)
+          (matchNbt ? JSON.stringify(item1.nbt) === JSON.stringify(item2.nbt) : true) &&
+          (matchNbt ? componentsEqual(item1, item2) : true)
         )
       }
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -448,6 +448,48 @@ describe('use Item.equal', () => {
   })
 })
 
+describe('use Item.equal with components (1.20.5+)', () => {
+  const Item = require('prismarine-item')('1.20.5')
+  const registry = require('prismarine-registry')('1.20.5')
+  const swordId = registry.itemsByName.diamond_sword.id
+
+  it('different custom_name component', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'custom_name', data: 'Excalibur' }] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [] })
+    expect(Item.equal(itemOne, itemTwo)).toStrictEqual(false)
+  })
+
+  it('different damage component', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'damage', data: 100 }] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'damage', data: 0 }] })
+    expect(Item.equal(itemOne, itemTwo)).toStrictEqual(false)
+  })
+
+  it('different enchantments component', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'enchantments', data: [{ name: 'sharpness', lvl: 5 }] }] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [] })
+    expect(Item.equal(itemOne, itemTwo)).toStrictEqual(false)
+  })
+
+  it('identical components', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'custom_name', data: 'Excalibur' }] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'custom_name', data: 'Excalibur' }] })
+    expect(Item.equal(itemOne, itemTwo)).toStrictEqual(true)
+  })
+
+  it('different removedComponents', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [], removeComponents: ['custom_name'] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [] })
+    expect(Item.equal(itemOne, itemTwo)).toStrictEqual(false)
+  })
+
+  it('matchNbt=false skips component comparison', () => {
+    const itemOne = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'custom_name', data: 'Excalibur' }] })
+    const itemTwo = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [] })
+    expect(Item.equal(itemOne, itemTwo, true, false)).toStrictEqual(true)
+  })
+})
+
 describe('durabilityUsed with damage component', () => {
   const Item = require('prismarine-item')('1.20.5')
 


### PR DESCRIPTION
## Problem

Since 1.20.5, item data (custom name, damage, enchantments, lore, repair cost, ...) is stored in `components`/`componentMap` instead of NBT. But `Item.equal` only compares `type`, `metadata`, `count` and `nbt` — so two items that differ **only** in their components are reported as equal.

Reproduction (1.20.5):
```js
const a = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [{ type: 'custom_name', data: 'Excalibur' }] })
const b = Item.fromNotch({ itemId: swordId, itemCount: 1, components: [] })
Item.equal(a, b) // true  <- wrong, should be false
```
Same for `damage`, `enchantments`, and `removedComponents` differences.

This is the root cause behind PrismarineJS/mineflayer#3933: mineflayer's `inventory.js` gates `updateSlot` on `Item.equal` (`if (!Item.equal(bot.inventory.slots[slot], item, true)) bot.inventory.updateSlot(slot, item)`), so on 1.20.5+ component changes (renames, damage, enchants) are silently dropped and items fail to synchronize.

## Fix

Add a `componentsEqual` helper that compares `componentMap` entries (by type and serialized data) and `removedComponents`, and evaluate it inside `Item.equal` under the existing `matchNbt` flag — components are the 1.20.5+ replacement for NBT item data, so they belong to the same "match item data" semantics.

- Pre-1.20.5 items have no `componentMap` and are completely unaffected (helper returns true immediately).
- `matchNbt=false` skips component comparison, consistent with skipping NBT.
- No signature change; fully backward compatible.

## Verification

- New regression tests cover: different `custom_name`, different `damage`, different `enchantments`, identical components, different `removedComponents`, and `matchNbt=false`.
- Full suite: **114 passing** (108 existing + 6 new), `standard` lint clean.