### PR TITLE
Expose the custom_data component as item.nbt on 1.20.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See http://www.minecraftwiki.net/wiki/Data_values#Data
 
 #### item.nbt
 
-Buffer.
+The item's NBT compound (prismarine-nbt shape), or `null`. On 1.20.5+ this is the `custom_data` component's compound, so consumers that read `item.nbt` keep working on servers that store display/lore data there.
 
 #### item.stackId
 

--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ function loader (registryOrVersion) {
           if (item.components) {
             for (const component of item.components) {
               item.componentMap.set(component.type, component)
+              // custom_data is the item's NBT compound; item.nbt aliases it (same shape as pre-1.20.5 nbt)
+              if (component.type === 'custom_data') item.nbt = component.data
             }
           }
           return item

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -637,3 +637,76 @@ describe('componentMap preferred over nbt (1.20.5+)', () => {
     expect(item.repairCost).toBe(10)
   })
 })
+
+describe('custom_data component exposed as item.nbt (1.20.5+)', () => {
+  const nbt = require('prismarine-nbt')
+  const displayName = '{"text":"Factions Immortal","color":"green"}'
+  const customData = nbt.comp({
+    display: nbt.comp({ Name: nbt.string(displayName), Lore: nbt.list(nbt.string(['{"text":"line 1"}'])) }),
+    RepairCost: nbt.int(3)
+  })
+
+  for (const version of ['1.20.5', '1.21.4', '26.1']) {
+    describe(version, () => {
+      const Item = require('prismarine-item')(version)
+      const bannerId = require('prismarine-registry')(version).itemsByName.green_banner.id
+
+      it('item.nbt is the custom_data compound', () => {
+        const item = Item.fromNotch({
+          itemId: bannerId,
+          itemCount: 1,
+          components: [{ type: 'custom_data', data: customData }],
+          removeComponents: []
+        })
+        expect(item.nbt).toBe(customData)
+        expect(item.nbt.value.display.value.Name.value).toBe(displayName)
+        expect(item.componentMap.get('custom_data').data).toBe(customData)
+      })
+
+      it('nbt-based getters read through custom_data when no dedicated component exists', () => {
+        const item = Item.fromNotch({
+          itemId: bannerId,
+          itemCount: 1,
+          components: [{ type: 'custom_data', data: customData }],
+          removeComponents: []
+        })
+        expect(item.customName).toBe(displayName)
+        expect(item.customLore).toStrictEqual(['{"text":"line 1"}'])
+        expect(item.repairCost).toBe(3)
+      })
+
+      it('dedicated components still take priority over custom_data', () => {
+        const item = Item.fromNotch({
+          itemId: bannerId,
+          itemCount: 1,
+          components: [
+            { type: 'custom_name', data: '{"text":"From Component"}' },
+            { type: 'custom_data', data: customData }
+          ],
+          removeComponents: []
+        })
+        expect(item.customName).toBe('{"text":"From Component"}')
+      })
+
+      it('item.nbt stays null without custom_data', () => {
+        const item = Item.fromNotch({
+          itemId: bannerId,
+          itemCount: 1,
+          components: [{ type: 'damage', data: 1 }],
+          removeComponents: []
+        })
+        expect(item.nbt).toBe(null)
+      })
+
+      it('toNotch round-trips custom_data unchanged', () => {
+        const item = Item.fromNotch({
+          itemId: bannerId,
+          itemCount: 1,
+          components: [{ type: 'custom_data', data: customData }],
+          removeComponents: []
+        })
+        expect(Item.toNotch(item).components).toStrictEqual([{ type: 'custom_data', data: customData }])
+      })
+    })
+  }
+})


### PR DESCRIPTION
On 1.20.5+ (`itemsWithComponents`) `fromNotch` kept the raw component list on `item.components` / `item.componentMap` and left `item.nbt` null. The `custom_data` component is the item's NBT compound (`anonymousNbt`, same shape `item.nbt` had before 1.20.5), and it is where many servers still carry display name, lore, repair cost and similar data. Consumers reading `item.nbt`, and this library's own nbt fallbacks in `customName`, `customLore`, `repairCost` and `enchants`, saw nothing on those servers.

`fromNotch` now points `item.nbt` at the `custom_data` compound. Dedicated components (`custom_name`, `lore`, ...) still take priority in the getters, and items without `custom_data` keep `nbt === null`. `toNotch` is unchanged; the component list still round-trips as-is.

Tests cover 1.20.5, 1.21.4 and 26.1: `item.nbt` identity, getter fallthrough, component priority, the no-`custom_data` case and the round trip.

Observed on a 26.1 production server whose shop GUI items only had names under `custom_data.display.Name`; reported as u9g/bot-harness#75.