### PR TITLE
Render an item's custom name in displayName

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,33 @@
 const nbt = require('prismarine-nbt')
 
+// Strips prismarine-nbt wrappers down to plain JS values; every nbt tag arrives as {type, value}.
+function nbtValue (v) {
+  if (v == null || typeof v !== 'object') return v
+  if (Array.isArray(v)) return v.map(nbtValue)
+  if (typeof v.type === 'string' && 'value' in v) return nbtValue(v.value)
+  const out = {}
+  for (const k of Object.keys(v)) out[k] = nbtValue(v[k])
+  return out
+}
+
+function safeJson (s) {
+  try { return JSON.parse(s) } catch { return s }
+}
+
+// Plain text of a chat component (an NBT compound/value, a parsed JSON object, a JSON string, or a
+// plain string); returns null when the input holds no component at all.
+function chatToText (c) {
+  if (c == null) return null
+  const v = nbtValue(typeof c === 'string' ? safeJson(c) : c)
+  if (typeof v === 'string') return v
+  if (Array.isArray(v)) return v.map(x => chatToText(x) ?? '').join('')
+  if (typeof v !== 'object' || v === null) return null
+  let out = ''
+  if (typeof v.text === 'string') out += v.text
+  if (v.extra != null) out += chatToText(v.extra) ?? ''
+  return out
+}
+
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
   class Item {
@@ -45,6 +73,8 @@ function loader (registryOrVersion) {
           if (variation) this.displayName = variation.displayName
         }
 
+        this.applyCustomName()
+
         // Can't initialize fields if the item was sent by the server
         if (!sentByServer) {
           // The 'itemEnum.maxDurability' checks to see if this item can lose durability
@@ -55,6 +85,14 @@ function loader (registryOrVersion) {
         this.displayName = 'unknown'
         this.stackSize = 1
       }
+    }
+
+    // Vanilla renders an item's custom name (1.20.5+ `custom_name` component, NBT `display.Name`
+    // before that) everywhere the item's name is shown, so displayName reflects it too: the plain
+    // text of the chat component, falling back to the item's own display name.
+    applyCustomName () {
+      const text = chatToText(this.customName)
+      if (text !== null) this.displayName = text
     }
 
     static equal (item1, item2, matchStackSize = true, matchNbt = true) {
@@ -160,6 +198,7 @@ function loader (registryOrVersion) {
               item.componentMap.set(component.type, component)
             }
           }
+          item.applyCustomName()
           return item
         } else if (registry.supportFeature('itemSerializationWillOnlyUsePresent')) {
           return new Item(networkItem.itemId, networkItem.itemCount, networkItem.nbtData, null, true)
@@ -200,11 +239,13 @@ function loader (registryOrVersion) {
     set customName (newName) {
       if (this.componentMap) {
         this.componentMap.set('custom_name', { type: 'custom_name', data: newName })
+        this.applyCustomName()
         return
       }
       if (!this.nbt) this.nbt = nbt.comp({})
       if (!this.nbt.value.display) this.nbt.value.display = { type: 'compound', value: {} }
       this.nbt.value.display.value.Name = nbt.string(newName)
+      this.applyCustomName()
     }
 
     get customLore () {

--- a/test/displayName.test.js
+++ b/test/displayName.test.js
@@ -1,0 +1,85 @@
+/* eslint-env mocha */
+
+const expect = require('expect').default
+
+describe('displayName follows the custom name', () => {
+  describe('1.21.4 (custom_name component)', () => {
+    const Item = require('prismarine-item')('1.21.4')
+
+    it('renders a wire-format NBT compound name', () => {
+      // What a server sends for §6§lBedWars Lobby §7#1: a chat component as NBT.
+      const item = Item.fromNotch({
+        itemCount: 1,
+        itemId: require('prismarine-registry')('1.21.4').itemsByName.red_bed.id,
+        addedComponentCount: 1,
+        removedComponentCount: 0,
+        components: [{
+          type: 'custom_name',
+          data: {
+            type: 'compound',
+            value: {
+              text: { type: 'string', value: '' },
+              extra: {
+                type: 'list',
+                value: {
+                  type: 'compound',
+                  value: [
+                    { color: { type: 'string', value: 'gold' }, text: { type: 'string', value: 'BedWars Lobby ' } },
+                    { color: { type: 'string', value: 'gray' }, text: { type: 'string', value: '#1' } }
+                  ]
+                }
+              }
+            }
+          }
+        }],
+        removeComponents: []
+      })
+      expect(item.displayName).toBe('BedWars Lobby #1')
+    })
+
+    it('renders a plain-string name and keeps displayName an own property', () => {
+      const item = new Item(require('prismarine-registry')('1.21.4').itemsByName.stone.id, 1)
+      expect(item.displayName).toBe('Stone')
+      item.customName = 'Fancy Rock'
+      expect(item.displayName).toBe('Fancy Rock')
+      expect(Object.prototype.hasOwnProperty.call(item, 'displayName')).toBe(true)
+      expect(JSON.parse(JSON.stringify(item)).displayName).toBe('Fancy Rock')
+    })
+
+    it('keeps the registry name when no custom name is set', () => {
+      const item = new Item(require('prismarine-registry')('1.21.4').itemsByName.diamond_sword.id, 1)
+      expect(item.displayName).toBe('Diamond Sword')
+    })
+
+    it('an empty custom name renders empty, like vanilla', () => {
+      const item = new Item(require('prismarine-registry')('1.21.4').itemsByName.stone.id, 1)
+      item.customName = { type: 'compound', value: { text: { type: 'string', value: '' } } }
+      expect(item.displayName).toBe('')
+    })
+  })
+
+  describe('1.16.5 (display.Name NBT)', () => {
+    const Item = require('prismarine-item')('1.16.5')
+    const registry = require('prismarine-registry')('1.16.5')
+
+    it('renders a JSON-string display.Name', () => {
+      const item = new Item(registry.itemsByName.stone.id, 1, {
+        type: 'compound',
+        name: '',
+        value: {
+          display: {
+            type: 'compound',
+            value: { Name: { type: 'string', value: '{"text":"Shop","color":"green"}' } }
+          }
+        }
+      })
+      expect(item.displayName).toBe('Shop')
+    })
+
+    it('renders a bare-string display.Name', () => {
+      const item = new Item(registry.itemsByName.stone.id, 1)
+      item.customName = 'Shop'
+      expect(item.displayName).toBe('Shop')
+    })
+  })
+})


### PR DESCRIPTION
### Problem

A server that names an item — the 1.20.5+ `custom_name` component, `display.Name` in NBT before that — renders that name everywhere the item's name is shown. `item.displayName` ignored it and always reported the name from the item registry.

That matters on any server whose GUIs are built out of named items. Reading a BedWars lobby selector on jartexnetwork gives six slots that all report `Red Bed` instead of `BedWars Lobby #1` … `#6`, and a server selector full of `Compass`, `Chest`, `Nether Star`. Anything that picks or aims by display name has nothing to go on; every caller ends up hand-rolling its own chat-component renderer over `item.customName`.

### Fix

Compute `displayName` from `customName` when one is present:

- in the constructor, after the registry name and any metadata variation are applied;
- in `fromNotch`, once the wire components have been folded into `componentMap` (the constructor runs before that, so the component isn't visible yet);
- in the `customName` setter, on both the component and the NBT path.

`chatToText` renders the chat component to plain text. It accepts the shapes that actually arrive: a prismarine-nbt compound (`{type, value}` wrappers, nested `extra` lists), a parsed JSON object, a JSON string, or a bare string — which is what `display.Name` holds pre-1.20.5.

`displayName` stays an own property assigned in the same places as before, so `JSON.stringify(item)` has exactly the shape it had. An empty custom name (`{text: ""}`) renders `""`, which is what vanilla shows there.

### Tests

`test/displayName.test.js` covers the wire-format NBT compound name (1.21.4 `custom_name` through `fromNotch`), a plain-string name through the setter, an empty component, the pre-1.20.5 `display.Name` JSON-string and bare-string paths, and the no-custom-name fallback. Five of the six fail without the change. The existing 108 tests pass unchanged, and `standard` is clean.

Also verified live against a 26.1 production server (jartexnetwork): the lobby selector's slots read their real names through `item.displayName`.