### PR TITLE
Read the custom name and lore components as the JSON string they used to be

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 const nbt = require('prismarine-nbt')
 
+// 1.20.5 moved the custom name and the lore into data components, which carry a chat component as
+// NBT; the display.Name and display.Lore tags they replaced carried the same component as the JSON
+// string the server wrote. Read the NBT back as that string so customName and customLore have one
+// shape on every version, the one index.d.ts promises.
+function chatComponentJson (component) {
+  if (component == null || typeof component === 'string') return component
+  const value = typeof component.type === 'string' && 'value' in component ? nbt.simplify(component) : component
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
 function loader (registryOrVersion) {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
   class Item {
@@ -192,7 +202,7 @@ function loader (registryOrVersion) {
 
     get customName () {
       if (this.componentMap?.has('custom_name')) {
-        return this.componentMap.get('custom_name').data
+        return chatComponentJson(this.componentMap.get('custom_name').data)
       }
       return this?.nbt?.value?.display?.value?.Name?.value ?? null
     }
@@ -209,7 +219,8 @@ function loader (registryOrVersion) {
 
     get customLore () {
       if (this.componentMap?.has('lore')) {
-        return this.componentMap.get('lore').data
+        const lore = this.componentMap.get('lore').data
+        return Array.isArray(lore) ? lore.map(chatComponentJson) : chatComponentJson(lore)
       }
       if (!this.nbt?.value?.display) return null
       return nbt.simplify(this.nbt).display.Lore ?? null

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 const expect = require('expect').default
+const nbt = require('prismarine-nbt')
 
 describe('test based on examples', () => {
   describe('1.8 iron shovel', () => {
@@ -481,6 +482,28 @@ describe('componentMap getters (1.20.5+)', () => {
       expect(item.customName).toBe('{"text":"My Sword"}')
     })
 
+    it('reads the NBT component the protocol sends as the JSON string', () => {
+      const item = Item.fromNotch({
+        itemId: 830,
+        itemCount: 1,
+        components: [
+          { type: 'custom_name', data: nbt.comp({ text: nbt.string('My Sword'), color: nbt.string('gold') }) }
+        ]
+      })
+      expect(item.customName).toBe('{"text":"My Sword","color":"gold"}')
+    })
+
+    it('reads a plain-text NBT component as the text, like the display.Name path', () => {
+      const item = Item.fromNotch({
+        itemId: 830,
+        itemCount: 1,
+        components: [
+          { type: 'custom_name', data: nbt.string('My Sword') }
+        ]
+      })
+      expect(item.customName).toBe('My Sword')
+    })
+
     it('falls back to null when componentMap has no custom_name and no nbt', () => {
       const item = Item.fromNotch({
         itemId: 830,
@@ -502,6 +525,23 @@ describe('componentMap getters (1.20.5+)', () => {
         ]
       })
       expect(item.customLore).toStrictEqual(loreData)
+    })
+
+    it('reads the NBT components the protocol sends as JSON strings', () => {
+      const item = Item.fromNotch({
+        itemId: 830,
+        itemCount: 1,
+        components: [
+          {
+            type: 'lore',
+            data: [
+              nbt.comp({ text: nbt.string('Line 1') }),
+              nbt.comp({ text: nbt.string('Line 2'), italic: nbt.byte(0) })
+            ]
+          }
+        ]
+      })
+      expect(item.customLore).toStrictEqual(['{"text":"Line 1"}', '{"text":"Line 2","italic":0}'])
     })
 
     it('falls back to null when componentMap has no lore and no nbt', () => {


### PR DESCRIPTION
## Problem

1.20.5 moved the custom name and the lore out of the `display.Name` / `display.Lore` tags into the `custom_name` and `lore` data components, which carry a chat component as NBT. `customName` and `customLore` hand that NBT straight back:

```js
// 26.1, an item out of a server GUI
item.customName
// { type: 'compound', value: { extra: [Object], text: [Object] } }
item.customLore
// [ { type: 'compound', value: { ... } }, ... ]
```

Two things break:

- `index.d.ts` declares `customName: string | null` and `customLore: string | string[] | null`, so every consumer that treats them as strings gets an object instead.
- Before 1.20.5 the same getters return the JSON string the server wrote, so the shape depends on the version. Rendering the name the usual way silently produces an empty message, because prismarine-chat gets a prismarine-nbt tag rather than a component:

```js
new ChatMessage(item.customName).toString() // '' on 1.20.5+, the name on 1.20.4
```

## Fix

Simplify the NBT and stringify it, so both paths return the JSON string. A component that is already a string (what the existing tests hand in) passes through unchanged, and a plain-text component reads back as its text, which is what the `display.Name` path returns for one.

## Tests

Three cases added under `componentMap getters (1.20.5+)` that build the components the way the protocol sends them, with `prismarine-nbt` tags. They fail on master (`108 passing, 3 failing`) and pass with the change (`111 passing`).
